### PR TITLE
adjusting default filters

### DIFF
--- a/default-filters/ec2.yaml
+++ b/default-filters/ec2.yaml
@@ -1,16 +1,16 @@
 and:
   - resource: "launch-time"
     op: "GreaterThanEqualTo"
-    value: 14
+    value: 7
   - resource: "cpu"
     op: "LessThanEqualTo"
     since: 1
-    value: 100
+    value: 5
   - resource: "network-in"
     op: "LessThanEqualTo"
-    since: 1
-    value: 100000000000
+    since: 7
+    value: 100000000
   - resource: "network-out"
     op: "LessThanEqualTo"
-    since: 1
-    value: 100000000000
+    since: 7
+    value: 100000000

--- a/default-filters/rds.yaml
+++ b/default-filters/rds.yaml
@@ -1,8 +1,8 @@
 and:
   - resource: "launch-time"
     op: "GreaterThanEqualTo"
-    value: 14
+    value: 7
   - resource: "database-connections"
     op: "LessThanEqualTo"
-    value: 100000
-    since: 1
+    value: 1
+    since: 7


### PR DESCRIPTION
Modified the following resources types, to make them more realistic to find idle resources
- EC2
- RDS