### PR TITLE
Add custodian gcp to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /src
 # Install Cloud Custodian
 RUN python3 -m venv custodian
 RUN . custodian/bin/activate && pip install c7n && pip install c7n-org
+RUN . custodian/bin/activate && pip install --upgrade pip && pip install c7n_gcp
 
 # SET CUSTODIAN envirnomet variables
 ENV C8R_CUSTODIAN="/src/custodian/bin/custodian"

--- a/default-filters/gcp/disks.yaml
+++ b/default-filters/gcp/disks.yaml
@@ -1,6 +1,3 @@
 and:
   - resource: "attachments"
     op: "IsEmpty"
-  - resource: "launch-time"
-    op: "GreaterThanEqualTo"
-    value: 0


### PR DESCRIPTION
Adding this `RUN . custodian/bin/activate && pip install --upgrade pip` because of this issue 
https://stackoverflow.com/questions/52904639/docker-build-taking-too-long-when-installing-grpcio-via-pip